### PR TITLE
fix: SDP candidate to enable remote connection

### DIFF
--- a/lib/sdp.js
+++ b/lib/sdp.js
@@ -60,15 +60,65 @@ function create(options = {}) {
           app: 'webrtc-datachannel',
           maxMessageSize: 1024,
         },
-        candidates: candidates.map(({ ip, port, type }, i) => ({
-          ip,
-          port,
-          type,
-          priority: 0xffff + i,
-          transport: 'udp',
-          component: i + 1,
-          foundation: i,
-        })),
+        // Doc about SDP candidates
+        // https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/candidate
+        // https://webrtcforthecurious.com/docs/02-signaling/#sdp-values-used-by-webrtc
+        // https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-ice-sip-sdp-39#page-18
+        // https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-sdp-14
+        // Future: Add mDNS candidate where the IP address is obscured.
+        candidates: candidates.map(({ ip, port, type }, i) => {
+          // TODO: Review candidates if server have more than a local ip and a public ip
+          const componentId = 1;
+          // Priority formula
+          // https://datatracker.ietf.org/doc/html/rfc8445#section-5.1.2
+          // The type preference MUST be an integer from 0 (lowest preference) to
+          // 126 (highest preference) inclusive
+          let typePreference = 0;
+          switch (type) {
+            case 'host':
+              typePreference = 126;
+              break;
+            case 'srflx':
+              typePreference = 64;
+              break;
+            case 'prflx':
+              typePreference = 16;
+              break;
+            case 'relay':
+              typePreference = 8;
+              break;
+          }
+          // The local preference MUST be an integer from 0 (lowest preference) to
+          //  65535 (highest preference) inclusive
+          const localPreference = type == 'host' ? 65535 : 0;
+          
+          const priority = 0x1000000 * typePreference + 
+            256 * localPreference +
+            256 - componentId;
+
+          if (i == 0) {
+            return {
+              ip,
+              port,
+              type,
+              priority,
+              transport: 'udp',
+              component: componentId,
+              foundation: i,
+            }
+          }
+          return {
+            ip,
+            port,
+            type,
+            priority,
+            transport: 'udp',
+            component: componentId,
+            foundation: i,
+            raddr: candidates[0].ip,
+            rport: candidates[0].port,
+          }
+        }),
       },
     ],
   });


### PR DESCRIPTION
SDP candidate updated:
- 'priority': A long, unsigned integer value indicating
    the priority of the candidate according to the remote peer.
    The larger this value is, the more preferable
    the remote peer considers this candidate to be.
    The procedures for computing candidate's priority is
    described in section 5.1.2 of [RFC8445].
- 'foundation': a string which uniquely identifies the candidate
    across multiple transports. The foundation can therefore
    be used to correlate candidates that are present on
    multiple RTCIceTransport objects.
- 'component': is a positive integer between 1 and 256 (inclusive)
    that identifies the specific component of the data stream for
    which this is a candidate.  It MUST start at 1 and MUST increment
    by 1 for each component of a particular candidate.